### PR TITLE
Changed enabled algs detection using new OQS API

### DIFF
--- a/dotnetOQS/KEM.cs
+++ b/dotnetOQS/KEM.cs
@@ -50,6 +50,9 @@ namespace OpenQuantumSafe
 
         [DllImport("oqs.dll", CallingConvention = CallingConvention.Cdecl)]
         extern private static int OQS_KEM_alg_count();
+
+        [DllImport("oqs.dll", CallingConvention = CallingConvention.Cdecl)]
+        extern private static int OQS_KEM_alg_is_enabled(string method_name);
         #endregion
 
         /// <summary>
@@ -77,12 +80,9 @@ namespace OpenQuantumSafe
                 string alg = Marshal.PtrToStringAnsi(OQS_KEM_alg_identifier(i));
                 supported.Add(alg);
                 // determine if the alg is enabled
-
-                IntPtr kemPtr = OQS_KEM_new(alg);
-                if (kemPtr != IntPtr.Zero)
+                if (OQS_KEM_alg_is_enabled(alg) == 1)
                 {
                     enabled.Add(alg);
-                    OQS_KEM_free(kemPtr);
                 }
             }
             EnabledMechanisms = enabled.ToImmutableList<string>();

--- a/dotnetOQS/Sig.cs
+++ b/dotnetOQS/Sig.cs
@@ -49,6 +49,9 @@ namespace OpenQuantumSafe
 
         [DllImport("oqs.dll", CallingConvention = CallingConvention.Cdecl)]
         extern private static int OQS_SIG_alg_count();
+
+        [DllImport("oqs.dll", CallingConvention = CallingConvention.Cdecl)]
+        extern private static int OQS_SIG_alg_is_enabled(string method_name);
         #endregion
 
         /// <summary>
@@ -76,12 +79,9 @@ namespace OpenQuantumSafe
                 string alg = Marshal.PtrToStringAnsi(OQS_SIG_alg_identifier(i));
                 supported.Add(alg);
                 // determine if the alg is enabled
-
-                IntPtr kemPtr = OQS_SIG_new(alg);
-                if (kemPtr != IntPtr.Zero)
+                if (OQS_SIG_alg_is_enabled(alg) == 1)
                 {
                     enabled.Add(alg);
-                    OQS_SIG_free(kemPtr);
                 }
             }
             EnabledMechanisms = enabled.ToImmutableList<string>();

--- a/dotnetOQSUnitTest/KEMTests.cs
+++ b/dotnetOQSUnitTest/KEMTests.cs
@@ -56,7 +56,7 @@ namespace dotnetOQSUnitTest
             byte[] wrong_ciphertext = new byte[ciphertext.Length];
             random.NextBytes(wrong_ciphertext);
             log("wrong_ciphertext: " + BytesToHex(wrong_ciphertext));
-            try { 
+            try {
                 kem.decaps(out shared_secret_2, wrong_ciphertext, secret_key);
                 // if the wrong value didn't trigger an exception, make sure the shared secret do not match
                 Assert.IsFalse(shared_secret_1.SequenceEqual(shared_secret_2), "wrong ciphertext, shared secrets should have been different");
@@ -67,7 +67,7 @@ namespace dotnetOQSUnitTest
             }
 
             // wrong secret key
-            byte[] wrong_secret_key= new byte[secret_key.Length];
+            byte[] wrong_secret_key = new byte[secret_key.Length];
             random.NextBytes(wrong_secret_key);
             log("wrong_secret_key: " + BytesToHex(wrong_secret_key));
             try
@@ -93,75 +93,12 @@ namespace dotnetOQSUnitTest
         }
 
         [TestMethod]
-        public void TestKEMFrodokem640aes()
+        public void TestAllKEMs()
         {
-            TestKEM("FrodoKEM-640-AES");
-        }
-
-        [TestMethod]
-        public void TestKEMFrodokem640shake()
-        {
-            TestKEM("FrodoKEM-640-SHAKE");
-        }
-
-        [TestMethod]
-        public void TestKEMFrodokem976aes()
-        {
-            TestKEM("FrodoKEM-976-AES");
-        }
-
-        [TestMethod]
-        public void TestKEMFrodokem976shake()
-        {
-            TestKEM("FrodoKEM-976-SHAKE");
-        }
-
-        [TestMethod]
-        public void TestKEMFrodokem1344aes()
-        {
-            TestKEM("FrodoKEM-1344-AES");
-        }
-
-        [TestMethod]
-        public void TestKEMFrodokem1344shake()
-        {
-            TestKEM("FrodoKEM-1344-SHAKE");
-        }
-
-        [TestMethod]
-        public void TestKEMNewhope512CCA()
-        {
-            TestKEM("NewHope-512-CCA");
-        }
-
-        [TestMethod]
-        public void TestKEMNewhope1024CCA()
-        {
-            TestKEM("NewHope-1024-CCA");
-        }
-
-        [TestMethod]
-        public void TestKEMSIDHp503()
-        {
-            TestKEM("Sidh-p503");
-        }
-
-        [TestMethod]
-        public void TestKEMSIDHp751()
-        {
-            TestKEM("Sidh-p751");
-        }
-
-        [TestMethod]
-        public void TestKEMSIKEp503()
-        {
-            TestKEM("Sike-p503");
-        }
-
-        [TestMethod]
-        public void TestKEMSIKEp751()
-        {
-            TestKEM("Sike-p751");
+            foreach (string kem in KEM.EnabledMechanisms)
+            {
+                TestKEM(kem);
+            }
         }
 
         [TestMethod]

--- a/dotnetOQSUnitTest/KEMTests.cs
+++ b/dotnetOQSUnitTest/KEMTests.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQuantumSafe;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace dotnetOQSUnitTest
 {
@@ -95,9 +96,18 @@ namespace dotnetOQSUnitTest
         [TestMethod]
         public void TestAllKEMs()
         {
+            var failedAlgs = new List<string>();
             foreach (string kem in KEM.EnabledMechanisms)
             {
-                TestKEM(kem);
+                try {
+                    TestKEM(kem);
+                }
+                catch (Exception e)
+                {
+                    failedAlgs.Add(kem);
+                }
+
+                Assert.IsTrue(failedAlgs.Count == 0, string.Join(", ", failedAlgs));
             }
         }
 

--- a/dotnetOQSUnitTest/KEMTests.cs
+++ b/dotnetOQSUnitTest/KEMTests.cs
@@ -102,7 +102,7 @@ namespace dotnetOQSUnitTest
                 try {
                     TestKEM(kem);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     failedAlgs.Add(kem);
                 }

--- a/dotnetOQSUnitTest/SigTests.cs
+++ b/dotnetOQSUnitTest/SigTests.cs
@@ -79,39 +79,12 @@ namespace dotnetOQSUnitTest
         }
 
         [TestMethod]
-        public void TestSigPicnicL1FS()
+        public void TestAllSigs()
         {
-            TestSig("picnic_L1_FS");
-        }
-
-        [TestMethod]
-        public void TestSigPicnicL1UR()
-        {
-            TestSig("picnic_L1_UR");
-        }
-
-        [TestMethod]
-        public void TestSigPicnicL3FS()
-        {
-            TestSig("picnic_L3_FS");
-        }
-
-        [TestMethod]
-        public void TestSigPicnicL3UR()
-        {
-            TestSig("picnic_L3_UR");
-        }
-
-        [TestMethod]
-        public void TestSigPicnicL5FS()
-        {
-            TestSig("picnic_L5_FS");
-        }
-
-        [TestMethod]
-        public void TestSigPicnicL5UR()
-        {
-            TestSig("picnic_L5_UR");
+            foreach (string sig in Sig.EnabledMechanisms)
+            {
+                TestSig(sig);
+            }
         }
 
         [TestMethod]

--- a/dotnetOQSUnitTest/SigTests.cs
+++ b/dotnetOQSUnitTest/SigTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQuantumSafe;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace dotnetOQSUnitTest
 {
@@ -81,9 +82,19 @@ namespace dotnetOQSUnitTest
         [TestMethod]
         public void TestAllSigs()
         {
+            var failedAlgs = new List<string>();
             foreach (string sig in Sig.EnabledMechanisms)
             {
-                TestSig(sig);
+                try
+                {
+                    TestSig(sig);
+                }
+                catch (Exception)
+                {
+                    failedAlgs.Add(sig);
+                }
+
+                Assert.IsTrue(failedAlgs.Count == 0, string.Join(", ", failedAlgs));
             }
         }
 


### PR DESCRIPTION
Changed enabled algs detection using new OQS API. Also replaced per-alg unit test to a use a test-all one, to avoid manually changing the list every time OQS adds/removes an alg.