### PR TITLE
Generalized caught exception type when feeding garbage to OQS api.

### DIFF
--- a/dotnetOQSUnitTest/KEMTests.cs
+++ b/dotnetOQSUnitTest/KEMTests.cs
@@ -62,7 +62,7 @@ namespace dotnetOQSUnitTest
                 // if the wrong value didn't trigger an exception, make sure the shared secret do not match
                 Assert.IsFalse(shared_secret_1.SequenceEqual(shared_secret_2), "wrong ciphertext, shared secrets should have been different");
             }
-            catch (OQSException)
+            catch (Exception)
             {
                 // exception expected
             }
@@ -77,7 +77,7 @@ namespace dotnetOQSUnitTest
                 // if the wrong value didn't trigger an exception, make sure the shared secret do not match
                 Assert.IsFalse(shared_secret_1.SequenceEqual(shared_secret_2), "wrong ciphertext, shared secrets should have been different");
             }
-            catch (OQSException)
+            catch (Exception)
             {
                 // exception expected
             }
@@ -106,9 +106,8 @@ namespace dotnetOQSUnitTest
                 {
                     failedAlgs.Add(kem);
                 }
-
-                Assert.IsTrue(failedAlgs.Count == 0, string.Join(", ", failedAlgs));
             }
+            Assert.IsTrue(failedAlgs.Count == 0, string.Join(", ", failedAlgs));
         }
 
         [TestMethod]

--- a/dotnetOQSUnitTest/SigTests.cs
+++ b/dotnetOQSUnitTest/SigTests.cs
@@ -93,9 +93,8 @@ namespace dotnetOQSUnitTest
                 {
                     failedAlgs.Add(sig);
                 }
-
-                Assert.IsTrue(failedAlgs.Count == 0, string.Join(", ", failedAlgs));
             }
+            Assert.IsTrue(failedAlgs.Count == 0, string.Join(", ", failedAlgs));
         }
 
         [TestMethod]


### PR DESCRIPTION
The new sike compressed algs failed when passed garbage input (random key, ciphertext); this sometimes resulted in a "division by zero" system exception, that wasn't caught by the test handler (expecting an OQSException). I generalized the catch statement to catch all exceptions instead.

Addresses issue #7. 