### PR TITLE
Update .net version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: Install pre-requisites
           command: |
             git clone --branch main --single-branch --depth 1 https://github.com/open-quantum-safe/liboqs.git
-            cd /root && wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && apt-get update && apt-get install -y apt-transport-https && apt-get update && apt-get install -y dotnet-sdk-3.1 && cd -
+            cd /root && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && apt-get update && apt-get install -y apt-transport-https && apt-get update && apt-get install -y dotnet-sdk-6.0 && cd -
       - run:
           name: Clone liboqs
           command: .circleci/clone_liboqs.sh
@@ -33,7 +33,7 @@ jobs:
           command: .circleci/build_liboqs.sh
       - run:
           name: Build wrapper
-          command: dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard1.2 -c Release -o bin/Release/dotnetOQS-netstandard1.2
+          command: dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin/Release/dotnetOQS-netstandard2.1
       - run:
           name: Build and run test app
           command: scripts/linux_sample_netcoreapp2.1_x64_build.sh && ./bin/Release/dotnetOQSSample-netcoreapp2.1-linux-x64/dotnetOQSSample
@@ -57,7 +57,7 @@ jobs:
           command: .circleci/build_liboqs.sh
       - run:
           name: Build wrapper
-          command: export PATH=~/.dotnet:$PATH && dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard1.2 -c Release -o bin/Release/dotnetOQS-netstandard1.2
+          command: export PATH=~/.dotnet:$PATH && dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin/Release/dotnetOQS-netstandard2.1
       - run:
           name: Build and run test app
           command: export PATH=~/.dotnet:$PATH && scripts/macos_sample_netcoreapp2.1_x64_build.sh && ./bin/Release/dotnetOQSSample-netcoreapp2.1-osx-x64/dotnetOQSSample

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ jobs:
           command: .circleci/build_liboqs.sh
       - run:
           name: Build wrapper
-          command: dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin/Release/dotnetOQS-netstandard2.1
+          command: dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f net6.0 -c Release -o bin/Release/dotnetOQS-net6.0
       - run:
           name: Build and run test app
-          command: scripts/linux_sample_netcoreapp2.1_x64_build.sh && ./bin/Release/dotnetOQSSample-netcoreapp2.1-linux-x64/dotnetOQSSample
+          command: scripts/linux_sample_net6.0_x64_build.sh && ./bin/Release/dotnetOQSSample-net6.0-linux-x64/dotnetOQSSample
 
   macOS:
     description: A template for running liboqs-dotnet tests on x64 macOS machines
@@ -57,10 +57,10 @@ jobs:
           command: .circleci/build_liboqs.sh
       - run:
           name: Build wrapper
-          command: export PATH=~/.dotnet:$PATH && dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin/Release/dotnetOQS-netstandard2.1
+          command: export PATH=~/.dotnet:$PATH && dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f net6.0 -c Release -o bin/Release/dotnetOQS-net6.0
       - run:
           name: Build and run test app
-          command: export PATH=~/.dotnet:$PATH && scripts/macos_sample_netcoreapp2.1_x64_build.sh && ./bin/Release/dotnetOQSSample-netcoreapp2.1-osx-x64/dotnetOQSSample
+          command: export PATH=~/.dotnet:$PATH && scripts/macos_sample_net6.0_x64_build.sh && ./bin/Release/dotnetOQSSample-net6.0-osx-x64/dotnetOQSSample
 
 workflows:
   version: 2.1

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ liboqs-dotnet is provided "as is", without warranty of any kind.  See [LICENSE.t
 Building
 --------
 
-Builds are tested using the Appveyor continuous integration system on Windows Server 2016 (Visual Studio 2017).  Builds have been tested manually on Windows 10 with Visual Studio 2017 (Community and Enterprise editions), Linux (Ubuntu 18.04 LTS) and macOS Mojave.
+Builds are tested using the Appveyor continuous integration system Visual Studio 2019.  Builds have been tested manually on Windows 11 with Visual Studio 2022, Linux (Ubuntu 18.04 LTS) and macOS Mojave.
 
 ### Prerequisites
 
 To build the .NET OQS wrapper you need a .NET development environment; see the Getting Started section on the [.NET Core](https://dotnet.github.io/) GitHub page for more information.
 
-The wrapper targets a minimum of version 1.2 of the .NET standard which supports a wide range of framework listed [here](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support). Version 2.1 is preferred for a smaller build size.
+The wrapper targets a minimum of version 2.1 of the .NET standard which supports a wide range of framework listed [here](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support).
 
-Installing .Net Core 3.1 SDK and above is recommended for the installation steps below which can be obtained [here](https://dotnet.microsoft.com/download/dotnet-core/3.1). (Higher SDK version supports building lower SDK version, though runtime have to be installed separately if you compile it as a framework dependent application.)
+Installing .Net Core 6.0 above is recommended for the installation steps below which can be obtained [here](https://dotnet.microsoft.com/download/dotnet-core/). (Higher SDK version supports building lower SDK version, though runtime have to be installed separately if you compile it as a framework dependent application.)
 
 To build `liboqs-dotnet` on archnitecture `<arch>` (where `<arch>` is one of the architecture supported by OQS and the dotnet wrapper, for example `x64`, `arm`, etc.), first download or clone this dotnet wrapper into a `liboqs-dotnet` folder, e.g.,
 
@@ -78,7 +78,7 @@ To build `liboqs-dotnet` on archnitecture `<arch>` (where `<arch>` is one of the
 
 ### Building .Net OQS wrapper (optional)
 
-The dotnetOQS wrapper can be built for a specific `<conf>` (`Debug` or `Release`) and target .NET Standard `<vNET>` (e.g., `1.2` or `2.1`) using the command line or Visual Studio (on Windows):
+The dotnetOQS wrapper can be built for a specific `<conf>` (`Debug` or `Release`) and target .NET Standard `<vNET>` (e.g., `2.1`) using the command line or Visual Studio (on Windows):
 
     :: For Windows
     dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard<vNET> -c <conf> -o bin\<configuration>\dotnetOQS-netstandard<vNET>
@@ -110,16 +110,10 @@ See the `scripts` folder for more compilation samples.
 
 The sample program can be ran using the command line or Visual Studio (on Windows):
 
-    :: For Windows (netcoreapp1.1)
-    dotnet bin\<conf>\dotnetOQSSample-netcoreapp<vNET>-<OS>-<arch>.dll
-    
-    :: For Windows (netcoreapp2.1 and above)
+     :: For Windows (netcoreapp2.1 and above)
     .\bin\<conf>\dotnetOQSSample-netcoreapp<vNET>-<OS>-<arch>\dotnetOQSSample.exe
     
-    :: For Linux / macOS (netcoreapp1.1)
-    dotnet bin/<conf>/dotnetOQSSample-netcoreapp<vNET>-<OS>-<arch>.dll
-    
-    :: For Linux / macOS (netcoreapp2.1 and above)
+     :: For Linux / macOS (netcoreapp2.1 and above)
     ./bin/<conf>/dotnetOQSSample-netcoreapp<vNET>-<OS>-<arch>/dotnetOQSSample
 
 The unit tests can be run using Visual Studio's "Test" menu. It is currently not possible to use `dotnet test` on Linux to execute the test case.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ liboqs-dotnet is provided "as is", without warranty of any kind.  See [LICENSE.t
 Building
 --------
 
-Builds are tested using the Appveyor continuous integration system Visual Studio 2019.  Builds have been tested manually on Windows 11 with Visual Studio 2022, Linux (Ubuntu 18.04 LTS) and macOS Mojave.
+Builds are tested using the Appveyor continuous integration system Visual Studio 2022.  Builds have been tested manually on Windows 11 with Visual Studio 2022, Linux (Ubuntu 18.04 LTS) and macOS Mojave.
 
 ### Prerequisites
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,6 @@ configuration:
   - Release
 
 test_script:
-  - dotnet %APPVEYOR_BUILD_FOLDER%\dotnetOQSSample\bin\%CONFIGURATION%\netcoreapp1.1\dotnetOQSSample.dll
-  - dotnet %APPVEYOR_BUILD_FOLDER%\dotnetOQSUnitTest\bin\%CONFIGURATION%\netcoreapp1.1\dotnetOQSUnitTest.dll
+  - dotnet %APPVEYOR_BUILD_FOLDER%\dotnetOQSSample\bin\%CONFIGURATION%\net6.0\dotnetOQSSample.dll
+  - dotnet %APPVEYOR_BUILD_FOLDER%\dotnetOQSUnitTest\bin\%CONFIGURATION%\net6.0\dotnetOQSUnitTest.dll
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 platform: x64
 
@@ -13,7 +13,7 @@ environment:
 
 before_build:
   - cmd: |-
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+      call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
       set PATH=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%;%PATH%
       git clone https://github.com/open-quantum-safe/liboqs %LIBOQS_INSTALL_PATH%
       mkdir %LIBOQS_BUILD_DIR%

--- a/dotnetOQS/dotnetOQS.csproj
+++ b/dotnetOQS/dotnetOQS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.2;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <RootNamespace>OQS</RootNamespace>
   </PropertyGroup>
   

--- a/dotnetOQS/dotnetOQS.csproj
+++ b/dotnetOQS/dotnetOQS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>OQS</RootNamespace>
   </PropertyGroup>
   

--- a/dotnetOQSSample/dotnetOQSSample.csproj
+++ b/dotnetOQSSample/dotnetOQSSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/dotnetOQSSample/dotnetOQSSample.csproj
+++ b/dotnetOQSSample/dotnetOQSSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
+++ b/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
@@ -6,6 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\dotnetOQS\dotnetOQS.csproj" />
   </ItemGroup>
 

--- a/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
+++ b/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
@@ -1,22 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PreBuildEvent>copy $(SolutionDir)x64\oqs.dll $(TargetDir)</PreBuildEvent>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\dotnetOQS\dotnetOQS.csproj" />

--- a/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
+++ b/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>    
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PreBuildEvent>copy $(SolutionDir)x64\oqs.dll $(TargetDir)</PreBuildEvent>
   </PropertyGroup>
 

--- a/scripts/linux_macos_wrapper_build.sh
+++ b/scripts/linux_macos_wrapper_build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Debug -o bin/Debug/dotnetOQS-netstandard2.1
-dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin/Release/dotnetOQS-netstandard2.1
+dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f net6.0 -c Debug -o bin/Debug/dotnetOQS-net6.0
+dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f net6.0 -c Release -o bin/Release/dotnetOQS-net6.0

--- a/scripts/linux_macos_wrapper_build.sh
+++ b/scripts/linux_macos_wrapper_build.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard1.2 -c Debug -o bin/Debug/dotnetOQS-netstandard1.2
-dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.0 -c Debug -o bin/Debug/dotnetOQS-netstandard2.0
-dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard1.2 -c Release -o bin/Release/dotnetOQS-netstandard1.2
-dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.0 -c Release -o bin/Release/dotnetOQS-netstandard2.0
+dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Debug -o bin/Debug/dotnetOQS-netstandard2.1
+dotnet build dotnetOQS/dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin/Release/dotnetOQS-netstandard2.1

--- a/scripts/linux_sample_net6.0_x64_build.sh
+++ b/scripts/linux_sample_net6.0_x64_build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=net6.0 -c Release -f net6.0 -o bin/Release/dotnetOQSSample-net6.0-linux-x64 -r linux-x64 --self-contained
+cp x64/liboqs.so bin/Release/dotnetOQSSample-net6.0-linux-x64

--- a/scripts/linux_sample_netcoreapp1.1_x64_build.sh
+++ b/scripts/linux_sample_netcoreapp1.1_x64_build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=netcoreapp1.1 -c Release -f netcoreapp1.1 -o bin/Release/dotnetOQSSample-netcoreapp1.1-linux-x64
-cp x64/liboqs.so bin/Release/dotnetOQSSample-netcoreapp1.1-linux-x64

--- a/scripts/linux_sample_netcoreapp2.1_x64_build.sh
+++ b/scripts/linux_sample_netcoreapp2.1_x64_build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=netcoreapp2.1 -c Release -f netcoreapp2.1 -o bin/Release/dotnetOQSSample-netcoreapp2.1-linux-x64 -r linux-x64 --self-contained
-cp x64/liboqs.so bin/Release/dotnetOQSSample-netcoreapp2.1-linux-x64

--- a/scripts/linux_sample_netcoreapp3.1_x64_build.sh
+++ b/scripts/linux_sample_netcoreapp3.1_x64_build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:PublishSingleFile=true /p:Platform=x64 /p:TargetFramework=netcoreapp3.1 -c Release -f netcoreapp3.1 -o bin/Release/dotnetOQSSample-netcoreapp3.1-linux-x64 -r linux-x64 --self-contained
-cp x64/liboqs.so bin/Release/dotnetOQSSample-netcoreapp3.1-linux-x64

--- a/scripts/macos_sample_net6.0_x64_build.sh
+++ b/scripts/macos_sample_net6.0_x64_build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=net6.0 -c Release -f net6.0 -o bin/Release/dotnetOQSSample-net6.0-osx-x64 -r osx-x64 --self-contained
+cp x64/liboqs.dylib bin/Release/dotnetOQSSample-net6.0-osx-x64

--- a/scripts/macos_sample_netcoreapp1.1_x64_build.sh
+++ b/scripts/macos_sample_netcoreapp1.1_x64_build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=netcoreapp1.1 -c Release -f netcoreapp1.1 -o bin/Release/dotnetOQSSample-netcoreapp1.1-osx-x64
-cp x64/liboqs.dylib bin/Release/dotnetOQSSample-netcoreapp1.1-osx-x64

--- a/scripts/macos_sample_netcoreapp2.1_x64_build.sh
+++ b/scripts/macos_sample_netcoreapp2.1_x64_build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=netcoreapp2.1 -c Release -f netcoreapp2.1 -o bin/Release/dotnetOQSSample-netcoreapp2.1-osx-x64 -r osx-x64 --self-contained
-cp x64/liboqs.dylib bin/Release/dotnetOQSSample-netcoreapp2.1-osx-x64

--- a/scripts/macos_sample_netcoreapp3.1_x64_build.sh
+++ b/scripts/macos_sample_netcoreapp3.1_x64_build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-dotnet publish dotnetOQSSample/dotnetOQSSample.csproj /p:PublishSingleFile=true /p:Platform=x64 /p:TargetFramework=netcoreapp3.1 -c Release -f netcoreapp3.1 -o bin/Release/dotnetOQSSample-netcoreapp3.1-osx-x64 -r osx-x64 --self-contained
-cp x64/liboqs.dylib bin/Release/dotnetOQSSample-netcoreapp3.1-osx-x64

--- a/scripts/win_sample_net6.0_x64_build.bat
+++ b/scripts/win_sample_net6.0_x64_build.bat
@@ -1,0 +1,4 @@
+@echo off
+
+dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=net6.0 -c Release -f net6.0 -o bin\Release\dotnetOQSSample-net6.0-win-x64 -r win-x64 --self-contained
+copy x64\oqs.dll bin\Release\dotnetOQSSample-net6.0-win-x64

--- a/scripts/win_sample_net6.0_x86_build.bat
+++ b/scripts/win_sample_net6.0_x86_build.bat
@@ -1,0 +1,4 @@
+@echo off
+
+dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:Platform=x86 /p:TargetFramework=net6.0 -c Release -f net6.0 -o bin\Release\dotnetOQSSample-net6.0-win-x86 -r win-x86 --self-contained
+copy x86\oqs.dll bin\Release\dotnetOQSSample-net6.0-win-x86

--- a/scripts/win_sample_netcoreapp1.1_x64_build.bat
+++ b/scripts/win_sample_netcoreapp1.1_x64_build.bat
@@ -1,4 +1,0 @@
-@echo off
-
-dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=netcoreapp1.1 -c Release -f netcoreapp1.1 -o bin\Release\dotnetOQSSample-netcoreapp1.1-win-x64
-copy x64\oqs.dll bin\Release\dotnetOQSSample-netcoreapp1.1-win-x64

--- a/scripts/win_sample_netcoreapp1.1_x86_build.bat
+++ b/scripts/win_sample_netcoreapp1.1_x86_build.bat
@@ -1,4 +1,0 @@
-@echo off
-
-dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:Platform=x86 /p:TargetFramework=netcoreapp1.1 -c Release -f netcoreapp1.1 -o bin\Release\dotnetOQSSample-netcoreapp1.1-win-x86
-copy x86\oqs.dll bin\Release\dotnetOQSSample-netcoreapp1.1-win-x86

--- a/scripts/win_sample_netcoreapp2.1_x64_build.bat
+++ b/scripts/win_sample_netcoreapp2.1_x64_build.bat
@@ -1,4 +1,0 @@
-@echo off
-
-dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:Platform=x64 /p:TargetFramework=netcoreapp2.1 -c Release -f netcoreapp2.1 -o bin\Release\dotnetOQSSample-netcoreapp2.1-win-x64 -r win-x64 --self-contained
-copy x64\oqs.dll bin\Release\dotnetOQSSample-netcoreapp2.1-win-x64

--- a/scripts/win_sample_netcoreapp2.1_x86_build.bat
+++ b/scripts/win_sample_netcoreapp2.1_x86_build.bat
@@ -1,4 +1,0 @@
-@echo off
-
-dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:Platform=x86 /p:TargetFramework=netcoreapp2.1 -c Release -f netcoreapp2.1 -o bin\Release\dotnetOQSSample-netcoreapp2.1-win-x86 -r win-x86 --self-contained
-copy x86\oqs.dll bin\Release\dotnetOQSSample-netcoreapp2.1-win-x86

--- a/scripts/win_sample_netcoreapp3.1_x64_build.bat
+++ b/scripts/win_sample_netcoreapp3.1_x64_build.bat
@@ -1,4 +1,0 @@
-@echo off
-
-dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:PublishSingleFile=true /p:Platform=x64 /p:TargetFramework=netcoreapp3.1 -c Release -f netcoreapp3.1 -o bin\Release\dotnetOQSSample-netcoreapp3.1-win-x64 -r win-x64 --self-contained
-copy x64\oqs.dll bin\Release\dotnetOQSSample-netcoreapp3.1-win-x64

--- a/scripts/win_sample_netcoreapp3.1_x86_build.bat
+++ b/scripts/win_sample_netcoreapp3.1_x86_build.bat
@@ -1,4 +1,0 @@
-@echo off
-
-dotnet publish dotnetOQSSample\dotnetOQSSample.csproj /p:PublishSingleFile=true /p:Platform=x86 /p:TargetFramework=netcoreapp3.1 -c Release -f netcoreapp3.1 -o bin\Release\dotnetOQSSample-netcoreapp3.1-win-x86 -r win-x86 --self-contained
-copy x86\oqs.dll bin\Release\dotnetOQSSample-netcoreapp3.1-win-x86

--- a/scripts/win_wrapper_build.bat
+++ b/scripts/win_wrapper_build.bat
@@ -1,7 +1,5 @@
 @echo off
 
-dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard1.2 -c Debug -o bin\Debug\dotnetOQS-netstandard1.2
-dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.0 -c Debug -o bin\Debug\dotnetOQS-netstandard2.0
+dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Debug -o bin\Debug\dotnetOQS-netstandard2.1
 
-dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard1.2 -c Release -o bin\Release\dotnetOQS-netstandard1.2
-dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.0 -c Release -o bin\Release\dotnetOQS-netstandard2.0
+dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin\Release\dotnetOQS-netstandard2.1

--- a/scripts/win_wrapper_build.bat
+++ b/scripts/win_wrapper_build.bat
@@ -1,5 +1,5 @@
 @echo off
 
-dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Debug -o bin\Debug\dotnetOQS-netstandard2.1
+dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f net6.0 -c Debug -o bin\Debug\dotnetOQS-net6.0
 
-dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f netstandard2.1 -c Release -o bin\Release\dotnetOQS-netstandard2.1
+dotnet build dotnetOQS\dotnetOQS.csproj /p:Platform=AnyCPU -f net6.0 -c Release -o bin\Release\dotnetOQS-net6.0


### PR DESCRIPTION
Updates .NET version. Moving to v6.0 for [LTS support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) (and to avoid doing this again at the end of the year). Also moves to VS 2022 (required for .NET v6.0 support).

Fixes #20.