### PR TITLE
Fix Classic McEliece stack overflow issue in unit test project

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The sample program can be ran using the command line or Visual Studio (on Window
 
 The unit tests can be run using Visual Studio's "Test" menu. It is currently not possible to use `dotnet test` on Linux to execute the test case.
 
+Please note the Classic McEliece algorithm requires a large stack.  If you experience a stack overflow exception, [try use editbin.exe to enlarge the stack size](https://github.com/open-quantum-safe/liboqs-dotnet/issues/25#issuecomment-1157162145).  The unit test project tests all algorithm including the Classic McEliece, so a PostBuildEvent PowerShell script is included to change the stack size of testhost.exe.  You will need install C and C++ support in Visual Studio for this script to locate editbin; alternatively, you can add editbin's path to the PATH environment variable.
+
 Troubleshooting
 ---------------
 

--- a/dotnetOQSUnitTest/IncStackSize.ps1
+++ b/dotnetOQSUnitTest/IncStackSize.ps1
@@ -1,0 +1,26 @@
+﻿param (
+    [Parameter(Mandatory=$true)][string]$targetDir
+)
+$editbinPath = (& cmd /c "where editbin.exe")
+if (!$editbinPath) {
+    # read registry default value
+    $devenvPath = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\devenv.exe" -ErrorAction SilentlyContinue)."(default)"
+    if (!$devenvPath) {
+        Write-Host "Failed to find Visaul Studio installled path"
+        exit 1
+    }
+    $searchRoot = [regex]::Match($devenvPath.Trim('"'), "^.+\\20[0-9]{2}\\").Value
+    if (!$searchRoot) {
+        Write-Host "Unrecognized Visual Studio installled path - $devenvPath"
+        exit 1
+    }
+    $searchRoot
+    $editbinPath = (Get-ChildItem -Path $searchRoot -Filter editbin.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+    $editbinPath 
+    if (!$editbinPath) {
+        Write-Host "Failed to find editbin.exe"
+        exit 1
+    }
+}
+& $editbinPath /STACK:50000000 $(Join-Path $targetDir "testhost.exe")
+

--- a/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
+++ b/dotnetOQSUnitTest/dotnetOQSUnitTest.csproj
@@ -1,23 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>net6.0</TargetFramework>
-    <PreBuildEvent>copy $(SolutionDir)x64\oqs.dll $(TargetDir)</PreBuildEvent>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<PreBuildEvent>copy $(SolutionDir)x64\oqs.dll $(TargetDir)</PreBuildEvent>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
-  </ItemGroup>
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<Exec Command="powershell $(TargetDir)IncStackSize.ps1 $(TargetDir)" />
+	</Target>
+	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\dotnetOQS\dotnetOQS.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\dotnetOQS\dotnetOQS.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+	<ItemGroup>
+		<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="IncStackSize.ps1">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Classic McEliece algorithm requires a large stack.   The unit test project tests all algorithm including the Classic McEliece so the test always crashes and return nothing.    

![image](https://github.com/open-quantum-safe/liboqs-dotnet/assets/572199/44054dfa-8718-416d-aa31-1d6c015e6d3d)

```
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
   at OpenQuantumSafe.KEM.OQS_KEM_keypair(IntPtr, Byte[], Byte[])
   at OpenQuantumSafe.KEM.keypair(Byte[] ByRef, Byte[] ByRef)
   at dotnetOQSUnitTest.KEMTests.TestKEM(System.String)
   at dotnetOQSUnitTest.KEMTests.TestAllKEMs()
```

I suggest adding a PostBuildEvent PowerShell script in csproj.  It will trye to find editbin and [enlarge the stack size](https://github.com/open-quantum-safe/liboqs-dotnet/issues/25#issuecomment-1157162145) of testhost.exe to fix the issue.

![image](https://github.com/open-quantum-safe/liboqs-dotnet/assets/572199/30efc345-5503-4451-b5df-31e7440f0f8e)
