### PR TITLE
Update README prior to archiving repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ liboqs-dotnet
 
 ## <span style="color: red;">DEPRECATION NOTICE</span>
 
-<b><span style="color: red;">The Open Quantum Safe project has discontinued development of our liboqs-dotnet language wrapper.  This repository is being archived as read-only.  Use of this code is not recommended, as it may rely on obsolete algorithms or implementations or may have security vulnerabilities or other bugs.</span></b>
+<b><span style="color: red;">The Open Quantum Safe project has discontinued development of our liboqs-dotnet language wrapper.  This repository is being archived as read-only.  Use of this code is not recommended, as it may rely on obsolete algorithms or implementations or may have security vulnerabilities or other bugs. If you are interested in reviving and maintaining this project, please reach out via the [OQS discussion board on Github](https://github.com/orgs/open-quantum-safe/discussions).</span></b>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+![Static Badge](https://img.shields.io/badge/status-deprecated-red)
+
+
 liboqs-dotnet
 =============
 
-[![Build status - Windows](https://ci.appveyor.com/api/projects/status/o3aqcf95kutixle5?svg=true)](https://ci.appveyor.com/project/dstebila/liboqs-dotnet), [![Build status CCI](https://circleci.com/gh/open-quantum-safe/liboqs-dotnet/tree/master.svg?style=svg)](https://circleci.com/gh/open-quantum-safe/liboqs-dotnet/tree/master)
+## <span style="color: red;">DEPRECATION NOTICE</span>
+
+<b><span style="color: red;">The Open Quantum Safe project has discontinued development of our liboqs-dotnet language wrapper.  This repository is being archived as read-only.  Use of this code is not recommended, as it may rely on obsolete algorithms or implementations or may have security vulnerabilities or other bugs.</span></b>
 
 ---
 


### PR DESCRIPTION
In the 2024-12-05 OQS TSC meeting, we agreed to archive this repository as read-only. This PR updates the README to indicate that. 

After merging, the following should occur:

- [x] Edit the "About" text for the repository to mark it as deprecated.
- [ ] Archive the repository.
- [ ] The OQS website should be updated to reflect that this is archived.